### PR TITLE
Make default task color configurable.

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -8,11 +8,14 @@
   "keikaku.reminder.hint": "You can change when this dialog is shown in the module settings.",
   "keikaku.reminder.button": "Open To-Do List",
 
-  "keikaku.settings.name": "Remind Players",
-  "keikaku.settings.hint": "During load a dialog pops up to remind players of the to-do list",
-  "keikaku.settings.choice.never": "Never",
-  "keikaku.settings.choice.incomplete": "Unfinished Tasks",
-  "keikaku.settings.choice.always": "Always",
+  "keikaku.settings.reminder.name": "Remind Players",
+  "keikaku.settings.reminder.hint": "During load a dialog pops up to remind players of the to-do list",
+  "keikaku.settings.reminder.choice.never": "Never",
+  "keikaku.settings.reminder.choice.incomplete": "Unfinished Tasks",
+  "keikaku.settings.reminder.choice.always": "Always",
+
+  "keikaku.settings.default_color.name": "Default Reminder Color",
+  "keikaku.settings.default_color.hint": "The default color of tasks",
 
   "keikaku.taskform.title": "Edit Task",
   "keikaku.taskform.field.color": "Color",

--- a/modules/keikaku.js
+++ b/modules/keikaku.js
@@ -6,17 +6,25 @@ import { initUiComponents, showReminder } from "./ui.js";
 /** Register Keikaku settings */
 function registerSettings() {
   game.settings.register("fvtt-keikaku", "showReminder", {
-    name: game.i18n.localize("keikaku.settings.name"),
-    hint: game.i18n.localize("keikaku.settings.hint"),
+    name: game.i18n.localize("keikaku.settings.reminder.name"),
+    hint: game.i18n.localize("keikaku.settings.reminder.hint"),
     scope: "client",
     config: true,
     type: String,
     choices: {
-      never: game.i18n.localize("keikaku.settings.choice.never"),
-      incomplete: game.i18n.localize("keikaku.settings.choice.incomplete"),
-      always: game.i18n.localize("keikaku.settings.choice.always"),
+      never: game.i18n.localize("keikaku.settings.reminder.choice.never"),
+      incomplete: game.i18n.localize("keikaku.settings.reminder.choice.incomplete"),
+      always: game.i18n.localize("keikaku.settings.reminder.choice.always"),
     },
     default: "always",
+  });
+  game.settings.register("fvtt-keikaku", "defaultColor", {
+    name: game.i18n.localize("keikaku.settings.default_color.name"),
+    hint: game.i18n.localize("keikaku.settings.default_color.hint"),
+    scope: "client",
+    config: true,
+    type: String,
+    default: "#191813",
   });
 }
 

--- a/modules/todo.js
+++ b/modules/todo.js
@@ -1,7 +1,6 @@
 /* global game */
 
 /** The default font color used by vanilla Foundry. **/
-const DEFAULT_COLOR = "#191813";
 const TAGS = {
   NONE: 0,
   IMPORTANT: 1,
@@ -19,7 +18,7 @@ export class Task {
   constructor(
     description = "",
     done = false,
-    color = DEFAULT_COLOR,
+    color = game.settings.get("fvtt-keikaku", "defaultColor"),
     tag = TAGS.NONE
   ) {
     /** The task's description. **/


### PR DESCRIPTION
This changeset makes the default font color of tasks user configurable via foundry settings.  It also changes the name of some of the settings localization strings to allow for the logical addition of more settings in the future.  These strings have been updated in the code.

Our GM is using this module and the custom stylesheet he uses has a dark background which makes the normal default color of `#191813` hard to read.  Having the ability to set the default color would make life easier. :D